### PR TITLE
fix: plausible request via https

### DIFF
--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -10,7 +10,7 @@ const { title } = Astro.props;
 <script
   defer
   data-domain="read.aamira.me"
-  src="http://plausible.aamira.me/js/script.outbound-links.js"></script>
+  src="https://plausible.aamira.me/js/script.outbound-links.js"></script>
 
 <!-- Open Graph tags -->
 <meta property="og:title" content="My New Astro Website" />


### PR DESCRIPTION
Firefox was blocking the http request so upgraded to https (even though plausible is down right now, should fix it in the future)